### PR TITLE
Revert "Change binary location to /usr/bin on Linux"

### DIFF
--- a/DoomRunner.pro
+++ b/DoomRunner.pro
@@ -79,7 +79,7 @@ FORMS += \
 
 # Default rules for deployment.
 qnx: target.path = /tmp/$${TARGET}/bin
-else: unix:!android: target.path = /usr/bin
+else: unix:!android: target.path = /opt/$${TARGET}/bin
 !isEmpty(target.path): INSTALLS += target
 
 DISTFILES += \


### PR DESCRIPTION
Sorry, this is a bit embarrassing. It looks like the correct place to but the binary would be in /opt 