### PR TITLE
Bugfix issue #42

### DIFF
--- a/Sources/MainWindow.cpp
+++ b/Sources/MainWindow.cpp
@@ -2250,9 +2250,9 @@ QString MainWindow::generateLaunchCommand( const QString & baseDir )
 		cmdStream << " -nomusic";
 
 	if (!ui->saveDirLine->text().isEmpty())
-		cmdStream << " -savedir " << ui->saveDirLine->text();
+		cmdStream << " -savedir \"" << ui->saveDirLine->text() << "\"";
 	if (!ui->screenshotDirLine->text().isEmpty())
-		cmdStream << " +screenshot_dir " << ui->screenshotDirLine->text();
+		cmdStream << " +screenshot_dir \"" << ui->screenshotDirLine->text() << "\"";
 
 	if (ui->launchMode_map->isChecked())
 	{


### PR DESCRIPTION
Adds parentheses when selecting paths for save & screenshot dirs

Fully-qualified paths (including those with spaces in!) will now properly work with -save_dir and +screenshot_dir commands