### PR TITLE
Use Uniform Initialization Syntax {} rather than parenthesis ()

### DIFF
--- a/Sources/Dialogs/DialogCommon.hpp
+++ b/Sources/Dialogs/DialogCommon.hpp
@@ -39,7 +39,7 @@ class DialogWithPaths : public DialogCommon {
 	QString lastUsedDir;  ///< the last directory the user selected via QFileDialog
 
 	DialogWithPaths( QWidget * thisWidget, PathConvertor pathConvertor )
-		: DialogCommon( thisWidget ), pathConvertor( std::move(pathConvertor) ) {}
+        : DialogCommon{ thisWidget }, pathConvertor{ std::move(pathConvertor) } {}
 
 	/// Runs a file-system dialog to let the user select a file and stores the its directory for the next call.
 	QString browseFile( QWidget * parent, const QString & fileDesc, QString startingDir, const QString & filter );

--- a/Sources/Dialogs/DialogCommon.hpp
+++ b/Sources/Dialogs/DialogCommon.hpp
@@ -39,7 +39,7 @@ class DialogWithPaths : public DialogCommon {
 	QString lastUsedDir;  ///< the last directory the user selected via QFileDialog
 
 	DialogWithPaths( QWidget * thisWidget, PathConvertor pathConvertor )
-        : DialogCommon{ thisWidget }, pathConvertor{ std::move(pathConvertor) } {}
+		: DialogCommon{ thisWidget }, pathConvertor{ std::move(pathConvertor) } {}
 
 	/// Runs a file-system dialog to let the user select a file and stores the its directory for the next call.
 	QString browseFile( QWidget * parent, const QString & fileDesc, QString startingDir, const QString & filter );

--- a/Sources/UserData.hpp
+++ b/Sources/UserData.hpp
@@ -55,7 +55,7 @@ struct Engine : public EditableListModelItem
 
 	Engine() {}
 	Engine( const QFileInfo & file )
-		: name( file.fileName() ), executablePath( file.filePath() ), configDir( file.dir().path() ), dataDir( configDir ) {}
+        : name{ file.fileName() }, executablePath{ file.filePath() }, configDir{ file.dir().path() }, dataDir{ configDir } {}
 
 	// requirements of EditableListModel
 	const QString & getFilePath() const   { return executablePath; }
@@ -87,7 +87,7 @@ struct Mod : public EditableListModelItem
 
 	Mod() {}
 	Mod( const QFileInfo & file, bool checked = true )
-		: path( file.filePath() ), fileName( file.fileName() ), checked( checked ) {}
+        : path{ file.filePath() }, fileName{ file.fileName() }, checked{ checked } {}
 
 	// requirements of EditableListModel
 	bool isEditable() const                 { return isCmdArg; }
@@ -270,7 +270,7 @@ struct Preset : public EditableListModelItem
 	EnvVars envVars;
 
 	Preset() {}
-	Preset( const QString & name ) : name( name ) {}
+    Preset( const QString & name ) : name{ name } {}
 	Preset( const QFileInfo & ) {}  // dummy, it's required by the EditableListModel template, but isn't actually used
 
 	// requirements of EditableListModel
@@ -345,7 +345,7 @@ struct WindowGeometry
 	int height = 0;
 
 	WindowGeometry() {}
-	WindowGeometry( const QRect & rect ) : width( rect.width() ), height( rect.height() ) {}
+    WindowGeometry( const QRect & rect ) : width{ rect.width() }, height{ rect.height() } {}
 };
 
 

--- a/Sources/UserData.hpp
+++ b/Sources/UserData.hpp
@@ -55,7 +55,7 @@ struct Engine : public EditableListModelItem
 
 	Engine() {}
 	Engine( const QFileInfo & file )
-        : name{ file.fileName() }, executablePath{ file.filePath() }, configDir{ file.dir().path() }, dataDir{ configDir } {}
+		: name{ file.fileName() }, executablePath{ file.filePath() }, configDir{ file.dir().path() }, dataDir{ configDir } {}
 
 	// requirements of EditableListModel
 	const QString & getFilePath() const   { return executablePath; }
@@ -87,7 +87,7 @@ struct Mod : public EditableListModelItem
 
 	Mod() {}
 	Mod( const QFileInfo & file, bool checked = true )
-        : path{ file.filePath() }, fileName{ file.fileName() }, checked{ checked } {}
+		: path{ file.filePath() }, fileName{ file.fileName() }, checked{ checked } {}
 
 	// requirements of EditableListModel
 	bool isEditable() const                 { return isCmdArg; }
@@ -270,7 +270,7 @@ struct Preset : public EditableListModelItem
 	EnvVars envVars;
 
 	Preset() {}
-    Preset( const QString & name ) : name{ name } {}
+	Preset( const QString & name ) : name{ name } {}
 	Preset( const QFileInfo & ) {}  // dummy, it's required by the EditableListModel template, but isn't actually used
 
 	// requirements of EditableListModel
@@ -345,7 +345,7 @@ struct WindowGeometry
 	int height = 0;
 
 	WindowGeometry() {}
-    WindowGeometry( const QRect & rect ) : width{ rect.width() }, height{ rect.height() } {}
+	WindowGeometry( const QRect & rect ) : width{ rect.width() }, height{ rect.height() } {}
 };
 
 

--- a/Sources/Utils/ContainerUtils.hpp
+++ b/Sources/Utils/ContainerUtils.hpp
@@ -76,7 +76,7 @@ class PointerIterator
 {
 	IterType _origIter;
  public:
-    PointerIterator( const IterType & origIter ) : _origIter{ origIter } {}
+	PointerIterator( const IterType & origIter ) : _origIter{ origIter } {}
 	auto operator*() -> decltype( **_origIter ) const { return **_origIter; }
 	auto operator->() -> decltype( *_origIter ) const { return *_origIter; }
 	PointerIterator & operator++() { ++_origIter; return *this; }
@@ -97,10 +97,10 @@ class span
 
  public:
 
-    span() : _begin{ nullptr }, _end{ nullptr } {}
-    span( Type * begin, Type * end ) : _begin{ begin }, _end{ end } {}
-    span( Type * data, int size ) : _begin{ data }, _end{ data + size } {}
-    span( Type * data, size_t size ) : _begin{ data }, _end{ data + size } {}
+	span() : _begin{ nullptr }, _end{ nullptr } {}
+	span( Type * begin, Type * end ) : _begin{ begin }, _end{ end } {}
+	span( Type * data, int size ) : _begin{ data }, _end{ data + size } {}
+	span( Type * data, size_t size ) : _begin{ data }, _end{ data + size } {}
 
 	Type * begin() const                   { return _begin; }
 	Type * end() const                     { return _end; }

--- a/Sources/Utils/ContainerUtils.hpp
+++ b/Sources/Utils/ContainerUtils.hpp
@@ -76,7 +76,7 @@ class PointerIterator
 {
 	IterType _origIter;
  public:
-	PointerIterator( const IterType & origIter ) : _origIter( origIter ) {}
+    PointerIterator( const IterType & origIter ) : _origIter{ origIter } {}
 	auto operator*() -> decltype( **_origIter ) const { return **_origIter; }
 	auto operator->() -> decltype( *_origIter ) const { return *_origIter; }
 	PointerIterator & operator++() { ++_origIter; return *this; }
@@ -97,10 +97,10 @@ class span
 
  public:
 
-	span() : _begin( nullptr ), _end( nullptr ) {}
-	span( Type * begin, Type * end ) : _begin( begin ), _end( end ) {}
-	span( Type * data, int size ) : _begin( data ), _end( data + size ) {}
-	span( Type * data, size_t size ) : _begin( data ), _end( data + size ) {}
+    span() : _begin{ nullptr }, _end{ nullptr } {}
+    span( Type * begin, Type * end ) : _begin{ begin }, _end{ end } {}
+    span( Type * data, int size ) : _begin{ data }, _end{ data + size } {}
+    span( Type * data, size_t size ) : _begin{ data }, _end{ data + size } {}
 
 	Type * begin() const                   { return _begin; }
 	Type * end() const                     { return _end; }

--- a/Sources/Utils/FileInfoCache.hpp
+++ b/Sources/Utils/FileInfoCache.hpp
@@ -62,7 +62,7 @@ class FileInfoCache : public LoggingComponent {
  public:
 
 	FileInfoCache( ReadFileInfoFunc readFileInfo )
-         : LoggingComponent{"FileInfoCache"}, _readFileInfo{ readFileInfo } {}
+        : LoggingComponent{"FileInfoCache"}, _readFileInfo{ readFileInfo } {}
 
 	/// Reads selected information from a file and stores it into a cache.
 	/** If the file was already read earlier and was not modified since, it returns the cached info. */

--- a/Sources/Utils/FileInfoCache.hpp
+++ b/Sources/Utils/FileInfoCache.hpp
@@ -62,7 +62,7 @@ class FileInfoCache : public LoggingComponent {
  public:
 
 	FileInfoCache( ReadFileInfoFunc readFileInfo )
-        : LoggingComponent{"FileInfoCache"}, _readFileInfo{ readFileInfo } {}
+		: LoggingComponent{"FileInfoCache"}, _readFileInfo{ readFileInfo } {}
 
 	/// Reads selected information from a file and stores it into a cache.
 	/** If the file was already read earlier and was not modified since, it returns the cached info. */

--- a/Sources/Utils/FileInfoCache.hpp
+++ b/Sources/Utils/FileInfoCache.hpp
@@ -62,7 +62,7 @@ class FileInfoCache : public LoggingComponent {
  public:
 
 	FileInfoCache( ReadFileInfoFunc readFileInfo )
-		: LoggingComponent("FileInfoCache"), _readFileInfo( readFileInfo ) {}
+         : LoggingComponent{"FileInfoCache"}, _readFileInfo{ readFileInfo } {}
 
 	/// Reads selected information from a file and stores it into a cache.
 	/** If the file was already read earlier and was not modified since, it returns the cached info. */

--- a/Sources/Utils/FileSystemUtils.hpp
+++ b/Sources/Utils/FileSystemUtils.hpp
@@ -188,7 +188,7 @@ class EntryTypes
 {
 	uint8_t _types;
  public:
-	constexpr EntryTypes( uint8_t types ) : _types( types ) {}
+    constexpr EntryTypes( uint8_t types ) : _types{ types } {}
 	constexpr friend EntryTypes operator|( EntryTypes a, EntryTypes b ) { return EntryTypes( a._types | b._types ); }
 	constexpr bool isSet( EntryTypes types ) const { return (_types & types._types) != 0; }
 };
@@ -218,10 +218,10 @@ class PathConvertor {
  public:
 
 	PathConvertor( const QDir & workingDir, PathStyle pathStyle )
-		: _workingDir( workingDir ), _pathStyle( pathStyle ) {}
+         : _workingDir{ workingDir }, _pathStyle{ pathStyle } {}
 
 	PathConvertor( const QDir & baseDir, bool useAbsolutePaths )
-		: PathConvertor( baseDir, useAbsolutePaths ? PathStyle::Absolute : PathStyle::Relative ) {}
+        : PathConvertor{ baseDir, useAbsolutePaths ? PathStyle::Absolute : PathStyle::Relative } {}
 
 	PathConvertor( const PathConvertor & other ) = default;
 	PathConvertor( PathConvertor && other ) = default;
@@ -264,7 +264,7 @@ class PathRebaser {
  public:
 
 	PathRebaser( const QDir & inputBaseDir, const QDir & outputBaseDir, PathStyle pathStyle, bool quotePaths = false )
-		: _inBaseDir( inputBaseDir ), _outBaseDir( outputBaseDir ), _outPathStyle( pathStyle ), _quotePaths( quotePaths ) {}
+         : _inBaseDir{ inputBaseDir }, _outBaseDir{ outputBaseDir }, _outPathStyle{ pathStyle }, _quotePaths{ quotePaths } {}
 
 	PathRebaser( const PathRebaser & other ) = default;
 	PathRebaser( PathRebaser && other ) = default;

--- a/Sources/Utils/FileSystemUtils.hpp
+++ b/Sources/Utils/FileSystemUtils.hpp
@@ -218,7 +218,7 @@ class PathConvertor {
  public:
 
 	PathConvertor( const QDir & workingDir, PathStyle pathStyle )
-         : _workingDir{ workingDir }, _pathStyle{ pathStyle } {}
+        : _workingDir{ workingDir }, _pathStyle{ pathStyle } {}
 
 	PathConvertor( const QDir & baseDir, bool useAbsolutePaths )
         : PathConvertor{ baseDir, useAbsolutePaths ? PathStyle::Absolute : PathStyle::Relative } {}
@@ -264,7 +264,7 @@ class PathRebaser {
  public:
 
 	PathRebaser( const QDir & inputBaseDir, const QDir & outputBaseDir, PathStyle pathStyle, bool quotePaths = false )
-         : _inBaseDir{ inputBaseDir }, _outBaseDir{ outputBaseDir }, _outPathStyle{ pathStyle }, _quotePaths{ quotePaths } {}
+        : _inBaseDir{ inputBaseDir }, _outBaseDir{ outputBaseDir }, _outPathStyle{ pathStyle }, _quotePaths{ quotePaths } {}
 
 	PathRebaser( const PathRebaser & other ) = default;
 	PathRebaser( PathRebaser && other ) = default;

--- a/Sources/Utils/FileSystemUtils.hpp
+++ b/Sources/Utils/FileSystemUtils.hpp
@@ -188,7 +188,7 @@ class EntryTypes
 {
 	uint8_t _types;
  public:
-    constexpr EntryTypes( uint8_t types ) : _types{ types } {}
+	constexpr EntryTypes( uint8_t types ) : _types{ types } {}
 	constexpr friend EntryTypes operator|( EntryTypes a, EntryTypes b ) { return EntryTypes( a._types | b._types ); }
 	constexpr bool isSet( EntryTypes types ) const { return (_types & types._types) != 0; }
 };
@@ -218,10 +218,10 @@ class PathConvertor {
  public:
 
 	PathConvertor( const QDir & workingDir, PathStyle pathStyle )
-        : _workingDir{ workingDir }, _pathStyle{ pathStyle } {}
+		: _workingDir{ workingDir }, _pathStyle{ pathStyle } {}
 
 	PathConvertor( const QDir & baseDir, bool useAbsolutePaths )
-        : PathConvertor{ baseDir, useAbsolutePaths ? PathStyle::Absolute : PathStyle::Relative } {}
+		: PathConvertor{ baseDir, useAbsolutePaths ? PathStyle::Absolute : PathStyle::Relative } {}
 
 	PathConvertor( const PathConvertor & other ) = default;
 	PathConvertor( PathConvertor && other ) = default;
@@ -264,7 +264,7 @@ class PathRebaser {
  public:
 
 	PathRebaser( const QDir & inputBaseDir, const QDir & outputBaseDir, PathStyle pathStyle, bool quotePaths = false )
-        : _inBaseDir{ inputBaseDir }, _outBaseDir{ outputBaseDir }, _outPathStyle{ pathStyle }, _quotePaths{ quotePaths } {}
+		: _inBaseDir{ inputBaseDir }, _outBaseDir{ outputBaseDir }, _outPathStyle{ pathStyle }, _quotePaths{ quotePaths } {}
 
 	PathRebaser( const PathRebaser & other ) = default;
 	PathRebaser( PathRebaser && other ) = default;

--- a/Sources/Utils/JsonUtils.hpp
+++ b/Sources/Utils/JsonUtils.hpp
@@ -82,9 +82,9 @@ class JsonValueCtx {
 		QString key;
 		int idx;
 
-		Key() : type( Uninitialized ), key(), idx( -1 ) {}
-		Key( const QString & key ) : type( ObjectKey ), key( key ), idx( -1 ) {}
-		Key( int idx ) : type( ArrayIndex ), key(), idx( idx ) {}
+        Key() : type{ Uninitialized }, key{}, idx{ -1 } {}
+        Key( const QString & key ) : type{ ObjectKey }, key{ key }, idx{ -1 } {}
+        Key( int idx ) : type{ ArrayIndex }, key{}, idx{ idx } {}
 	};
 
 	_ParsingContext * _context;  ///< document-wide context shared among all elements of that document, the struct is stored in JsonDocumentCtx
@@ -98,20 +98,20 @@ class JsonValueCtx {
 	/** This should only be used to indicate missing element or failure.
 	  * Anything else than isValid() or operator bool() is undefined. */
 	JsonValueCtx()
-		: _context( nullptr ), _parent( nullptr ), _key() {}
+         : _context{ nullptr }, _parent{ nullptr }, _key{} {}
 
 	/// Constructs a JSON value with no parent.
 	/** This should only be used for creating a root element. */
 	JsonValueCtx( _ParsingContext * context )
-		: _context( context ), _parent( nullptr ), _key() {}
+        : _context{ context }, _parent{ nullptr }, _key{} {}
 
 	/// Constructs a JSON value with a parent that is a JSON object.
 	JsonValueCtx( _ParsingContext * context, const JsonValueCtx * parent, const QString & key )
-		: _context( context ), _parent( parent ), _key( key ) {}
+        : _context{ context }, _parent{ parent }, _key{ key } {}
 
 	/// Constructs a JSON value with a parent that is a JSON array.
 	JsonValueCtx( _ParsingContext * context, const JsonValueCtx * parent, int index )
-		: _context( context ), _parent( parent ), _key( index ) {}
+        : _context{ context }, _parent{ parent }, _key{ index } {}
 
 	JsonValueCtx( const JsonValueCtx & ) = default;
 	JsonValueCtx( JsonValueCtx && ) = default;

--- a/Sources/Utils/JsonUtils.hpp
+++ b/Sources/Utils/JsonUtils.hpp
@@ -82,9 +82,9 @@ class JsonValueCtx {
 		QString key;
 		int idx;
 
-        Key() : type{ Uninitialized }, key{}, idx{ -1 } {}
-        Key( const QString & key ) : type{ ObjectKey }, key{ key }, idx{ -1 } {}
-        Key( int idx ) : type{ ArrayIndex }, key{}, idx{ idx } {}
+		Key() : type{ Uninitialized }, key{}, idx{ -1 } {}
+		Key( const QString & key ) : type{ ObjectKey }, key{ key }, idx{ -1 } {}
+		Key( int idx ) : type{ ArrayIndex }, key{}, idx{ idx } {}
 	};
 
 	_ParsingContext * _context;  ///< document-wide context shared among all elements of that document, the struct is stored in JsonDocumentCtx
@@ -98,20 +98,20 @@ class JsonValueCtx {
 	/** This should only be used to indicate missing element or failure.
 	  * Anything else than isValid() or operator bool() is undefined. */
 	JsonValueCtx()
-        : _context{ nullptr }, _parent{ nullptr }, _key{} {}
+		: _context{ nullptr }, _parent{ nullptr }, _key{} {}
 
 	/// Constructs a JSON value with no parent.
 	/** This should only be used for creating a root element. */
 	JsonValueCtx( _ParsingContext * context )
-        : _context{ context }, _parent{ nullptr }, _key{} {}
+		: _context{ context }, _parent{ nullptr }, _key{} {}
 
 	/// Constructs a JSON value with a parent that is a JSON object.
 	JsonValueCtx( _ParsingContext * context, const JsonValueCtx * parent, const QString & key )
-        : _context{ context }, _parent{ parent }, _key{ key } {}
+		: _context{ context }, _parent{ parent }, _key{ key } {}
 
 	/// Constructs a JSON value with a parent that is a JSON array.
 	JsonValueCtx( _ParsingContext * context, const JsonValueCtx * parent, int index )
-        : _context{ context }, _parent{ parent }, _key{ index } {}
+		: _context{ context }, _parent{ parent }, _key{ index } {}
 
 	JsonValueCtx( const JsonValueCtx & ) = default;
 	JsonValueCtx( JsonValueCtx && ) = default;

--- a/Sources/Utils/JsonUtils.hpp
+++ b/Sources/Utils/JsonUtils.hpp
@@ -98,7 +98,7 @@ class JsonValueCtx {
 	/** This should only be used to indicate missing element or failure.
 	  * Anything else than isValid() or operator bool() is undefined. */
 	JsonValueCtx()
-         : _context{ nullptr }, _parent{ nullptr }, _key{} {}
+        : _context{ nullptr }, _parent{ nullptr }, _key{} {}
 
 	/// Constructs a JSON value with no parent.
 	/** This should only be used for creating a root element. */

--- a/Sources/Utils/LangUtils.hpp
+++ b/Sources/Utils/LangUtils.hpp
@@ -23,7 +23,7 @@ class ScopeGuard
 {
 	EndFunc _atEnd;
  public:
-    ScopeGuard( EndFunc endFunc ) : _atEnd{ std::move(endFunc) } {}
+	ScopeGuard( EndFunc endFunc ) : _atEnd{ std::move(endFunc) } {}
 	~ScopeGuard() noexcept { _atEnd(); }
 };
 
@@ -47,7 +47,7 @@ class AutoClosable
 
  public:
 
-    AutoClosable( Handle handle, CloseFunc closeFunc ) : _handle{ handle }, _closeFunc{ closeFunc } {}
+	AutoClosable( Handle handle, CloseFunc closeFunc ) : _handle{ handle }, _closeFunc{ closeFunc } {}
 	AutoClosable( const AutoClosable & other ) = delete;
 
 	void letGo()

--- a/Sources/Utils/LangUtils.hpp
+++ b/Sources/Utils/LangUtils.hpp
@@ -23,7 +23,7 @@ class ScopeGuard
 {
 	EndFunc _atEnd;
  public:
-	ScopeGuard( EndFunc endFunc ) : _atEnd( std::move(endFunc) ) {}
+    ScopeGuard( EndFunc endFunc ) : _atEnd{ std::move(endFunc) } {}
 	~ScopeGuard() noexcept { _atEnd(); }
 };
 
@@ -47,7 +47,7 @@ class AutoClosable
 
  public:
 
-	AutoClosable( Handle handle, CloseFunc closeFunc ) : _handle( handle ), _closeFunc( closeFunc ) {}
+    AutoClosable( Handle handle, CloseFunc closeFunc ) : _handle{ handle }, _closeFunc{ closeFunc } {}
 	AutoClosable( const AutoClosable & other ) = delete;
 
 	void letGo()

--- a/Sources/Utils/TimeStats.hpp
+++ b/Sources/Utils/TimeStats.hpp
@@ -15,7 +15,7 @@ class TimeStats
 public:
 
 	TimeStats( const QString & fileName )
-        : logFile{ fileName }
+		: logFile{ fileName }
 	{
 		logFile.open( QFile::WriteOnly );
 		reset();

--- a/Sources/Utils/TimeStats.hpp
+++ b/Sources/Utils/TimeStats.hpp
@@ -15,7 +15,7 @@ class TimeStats
 public:
 
 	TimeStats( const QString & fileName )
-		: logFile( fileName )
+        : logFile{ fileName }
 	{
 		logFile.open( QFile::WriteOnly );
 		reset();

--- a/Sources/Version.hpp
+++ b/Sources/Version.hpp
@@ -30,8 +30,8 @@ struct Version
 	uint16_t patch;
 	uint16_t build;
 
-	Version() : major(0), minor(0), patch(0), build(0) {}
-	Version( uint16_t m, uint16_t n, uint16_t p = 0, uint16_t b = 0 ) : major(m), minor(n), patch(p), build(b) {}
+    Version() : major{0}, minor{0}, patch{0}, build{0} {}
+    Version( uint16_t m, uint16_t n, uint16_t p = 0, uint16_t b = 0 ) : major{m}, minor{n}, patch{p}, build{b} {}
 	Version( const char * versionStr );
 	Version( const QString & versionStr );
 

--- a/Sources/Version.hpp
+++ b/Sources/Version.hpp
@@ -30,8 +30,8 @@ struct Version
 	uint16_t patch;
 	uint16_t build;
 
-    Version() : major{0}, minor{0}, patch{0}, build{0} {}
-    Version( uint16_t m, uint16_t n, uint16_t p = 0, uint16_t b = 0 ) : major{m}, minor{n}, patch{p}, build{b} {}
+	Version() : major{0}, minor{0}, patch{0}, build{0} {}
+	Version( uint16_t m, uint16_t n, uint16_t p = 0, uint16_t b = 0 ) : major{m}, minor{n}, patch{p}, build{b} {}
 	Version( const char * versionStr );
 	Version( const QString & versionStr );
 

--- a/Sources/Widgets/ListModel.hpp
+++ b/Sources/Widgets/ListModel.hpp
@@ -54,7 +54,7 @@ class DropTarget {
 
  public:
 
-    DropTarget() : _dropped{ false }, _droppedRow{ 0 }, _droppedCount{ 0 } {}
+	DropTarget() : _dropped{ false }, _droppedRow{ 0 }, _droppedCount{ 0 } {}
 
 	bool wasDroppedInto() const { return _dropped; }
 	int droppedRow() const { return _droppedRow; }

--- a/Sources/Widgets/ListModel.hpp
+++ b/Sources/Widgets/ListModel.hpp
@@ -54,7 +54,7 @@ class DropTarget {
 
  public:
 
-	DropTarget() : _dropped( false ), _droppedRow( 0 ), _droppedCount( 0 ) {}
+    DropTarget() : _dropped{ false }, _droppedRow{ 0 }, _droppedCount{ 0 } {}
 
 	bool wasDroppedInto() const { return _dropped; }
 	int droppedRow() const { return _droppedRow; }


### PR DESCRIPTION
Change Initializer Lists in Constructors to use Uniform Initialization  Syntax rather than parenthesis. Fixes build in FreeBSD due to major() and minor() macros in sys/types.h causing an issue in Version.hpp.