### PR TITLE
Add recognition for EDGE (.epk) and k8vavoom (.vwad) archives

### DIFF
--- a/Sources/DoomFiles.cpp
+++ b/Sources/DoomFiles.cpp
@@ -23,8 +23,8 @@ const QStringVec configFileSuffixes = {"ini", "cfg"};
 const QString saveFileSuffix = "zds";
 const QString demoFileSuffix = "lmp";
 
-const QStringVec iwadSuffixes = {"wad", "iwad", "pk3", "ipk3", "pk7", "ipk7", "pkz", "pke"};
-const QStringVec pwadSuffixes = {"wad", "pwad", "pk3", "pk7", "pkz", "pke", "zip", "7z", "deh", "bex", "hhe"};
+const QStringVec iwadSuffixes = {"wad", "iwad", "pk3", "ipk3", "pk7", "ipk7", "pkz", "pke", "epk", "vwad"};
+const QStringVec pwadSuffixes = {"wad", "pwad", "pk3", "pk7", "pkz", "pke", "zip", "7z", "deh", "bex", "hhe", "epk", "vwad"};
 const QStringVec dukeSuffixes = {"grp", "rff"};
 
 // The correct way would be to recognize the type by file header, but there are incorrectly made mods


### PR DESCRIPTION
This adds the extensions for EPKs (EDGE zip archives) and VWADs (k8vavoom vwad archives, [as detailed in the k8vavoom git repo here](https://repo.or.cz/k8vavoom.git/blob_plain/HEAD:/libs/core/libvwad/vwadvfs.h)). EPKs and VWADs can contain standalone games (or simply IWADs that are stored in these archives) so I added it under both the iwad and pwad lists.