### PR TITLE
Fix app metainfo

### DIFF
--- a/Install/XDG/io.github.Youda008.DoomRunner.appdata.xml
+++ b/Install/XDG/io.github.Youda008.DoomRunner.appdata.xml
@@ -6,7 +6,9 @@
   <summary>Preset-oriented graphical launcher of ZDoom and derivatives</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
-  <developer_name>Youda008</developer_name>
+  <developer id="io.github.youda008">
+    <name>Youda008</name>
+  </developer>
   <url type="homepage">https://github.com/Youda008/DoomRunner</url>
   <url type="bugtracker">https://github.com/Youda008/DoomRunner/issues</url>
   <url type="help">https://github.com/Youda008/DoomRunner#readme</url>
@@ -42,8 +44,8 @@
     <content_attribute id="violence-bloodshed">moderate</content_attribute>
   </content_rating>
   <releases>
-    <release version="1.8.1" date="2023-08-05"><url>https://github.com/Youda008/DoomRunner/releases/tag/v1.8.1</url></release>
     <release version="1.8.2" date="2024-01-15"><url>https://github.com/Youda008/DoomRunner/releases/tag/v1.8.2</url></release>
+    <release version="1.8.1" date="2023-08-05"><url>https://github.com/Youda008/DoomRunner/releases/tag/v1.8.1</url></release>
   </releases>
   <provides>
     <binary>DoomRunner</binary>


### PR DESCRIPTION
The severe linter reports that something it's no good:

```shell
$ flatpak --user run --command=flatpak-builder-lint org.flatpak.Builder appstream io.github.Youda008.DoomRunner.appdata.xml
I: io.github.Youda008.DoomRunner:9: developer-name-tag-deprecated
   The toplevel `developer_name` element is deprecated. Please use the `name` element in a
   `developer` block instead.

W: io.github.Youda008.DoomRunner:~: releases-not-in-order 1.8.1 << 1.8.2
   The releases are not sorted in a latest to oldest version order. This is required as some tools
   will assume that the latest version is always at the top. Sorting releases also increases
   overall readability of the metainfo file.

I: io.github.Youda008.DoomRunner:~: developer-info-missing
   This component contains no `developer` element with information about its author.
```