### PR TITLE
Change menu bar qt/native status

### DIFF
--- a/Forms/MainWindow.ui
+++ b/Forms/MainWindow.ui
@@ -2188,6 +2188,9 @@
      <height>22</height>
     </rect>
    </property>
+   <property name="nativeMenuBar">
+    <bool>false</bool>
+   </property>
    <widget class="QMenu" name="menuItemMenu">
     <property name="title">
      <string>Menu</string>


### PR DESCRIPTION
Fixes the problem of the menu bar being nonexistent on some systems.

Edit:
I can only really speak about the current rolling-release of kwin (apparently) breaking native menu bars in qt5 apps.
This PR essentially just overrides the default setting for menu bar handling and makes qt fully handle it instead of the host system.
![Comparison](https://github.com/user-attachments/assets/68f9c88d-900a-4ee9-9e34-974410c5c396)
