### PR TITLE
Add conditional to enable cheats if (G)ZDoom

### DIFF
--- a/Sources/MainWindow.cpp
+++ b/Sources/MainWindow.cpp
@@ -573,6 +573,11 @@ bool MainWindow::shouldEnableAltScreenshotDir( const EngineInfo * selectedEngine
 	return !usePresetName && selectedEngine && selectedEngine->screenshotDirParam();
 }
 
+bool MainWindow::shouldEnableAllowCheats(const EngineInfo * selectedEngine)
+{
+    return selectedEngine && selectedEngine->name.contains("ZDoom", Qt::CaseInsensitive);
+}
+
 // disabling and clearing widgets
 
 [[maybe_unused]] static void toggleAndUncheck( QGroupBox * widget, bool enabled )
@@ -2661,6 +2666,7 @@ void MainWindow::toggleAndClearEngineDependentWidgets( const EngineInfo * engine
 	ui->engineDirBtn->setEnabled( shouldEnableEngineDirBtn( engine ) );
 	toggleAndDeselect( ui->configCmbBox, shouldEnableConfigCmbBox( engine ) );
 	ui->configCloneBtn->setEnabled( shouldEnableConfigCloneBtn( engine ) );
+	ui->allowCheatsChkBox->setEnabled( shouldEnableAllowCheats( engine ) );
 
 	LaunchMode mode = getLaunchModeFromUI();
 	bool multEnabled = ui->multiplayerGrpBox->isChecked();
@@ -3416,6 +3422,8 @@ void MainWindow::toggleOptionsSubwidgets( LaunchMode mode )
 	ui->pistolStartChkBox->setEnabled( enableBasicGameplayOptions );
 
 	const EngineInfo * selectedEngine = getSelectedEngine();
+	ui->allowCheatsChkBox->setEnabled( shouldEnableAllowCheats( selectedEngine ) );
+
 	ui->gameOptsBtn->setEnabled( shouldEnableGameOptsBtn( mode, selectedEngine ) );
 	ui->compatOptsBtn->setEnabled( shouldEnableCompatOptsBtn( mode, selectedEngine ) );
 	bool enableCompatModeSelector = shouldEnableCompatModeCmbBox( mode, selectedEngine );

--- a/Sources/MainWindow.hpp
+++ b/Sources/MainWindow.hpp
@@ -353,6 +353,7 @@ class MainWindow : public QMainWindow, private DialogWithPaths {
 	static bool shouldEnableAltConfigDir( const EngineInfo * selectedEngine, bool usePresetName );
 	static bool shouldEnableAltSaveDir( const EngineInfo * selectedEngine, bool usePresetName );
 	static bool shouldEnableAltScreenshotDir( const EngineInfo * selectedEngine, bool usePresetName );
+	static bool shouldEnableAllowCheats(const EngineInfo * selectedEngine);
 
 	LaunchMode getLaunchModeFromUI() const;
 


### PR DESCRIPTION
Since some engines like `dsda-doom` may not support `+sv_cheats 1` (e.g. causes a crash upon launch with `Unable to find required file "+sv_cheats"`), ensure the **_Force allow cheats_** checkbox is only enabled for the ZDoom family of engines.