### PR TITLE
fix: enable visibility of symbolic links in file browser (#288)

### DIFF
--- a/Sources/MainWindow.cpp
+++ b/Sources/MainWindow.cpp
@@ -1124,7 +1124,7 @@ void MainWindow::setupMapPackList()
 	ui->mapDirView->setSelectionMode( QAbstractItemView::ExtendedSelection );
 
 	// set item filters
-	mapModel.setFilter( QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks );
+	mapModel.setFilter( QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot );
 	mapModel.setNameFilters( makeFileSystemModelFilter( doom::getModSuffixes() ) );
 	mapModel.setNameFilterDisables( false );
 


### PR DESCRIPTION
As discussed in #288, this change removes the QDir::NoSymLinks filter to allow symbolic links to be visible in the file browser.